### PR TITLE
Possibility to ignore bucket policy and fix for repeated file name.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,6 +205,7 @@ S3_PORT=443
 S3_ENDPOINT=s3.domain.com
 S3_REGION=eu-west-3
 S3_USE_SSL=true
+S3_IGNORE_POLICY=false
 
 # AMAZON S3 - Environment variables
 # S3_ENABLED=true

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -400,7 +400,7 @@ export class EvolutionStartupService extends ChannelStartupService {
 
             const size = buffer.byteLength;
 
-            const fullName = join(`${this.instance.id}`, messageRaw.key.remoteJid, mediaType, fileName);
+            const fullName = join(`${this.instance.id}`, messageRaw.key.remoteJid, mediaType, v4().replace(/-/g, ""), fileName);
 
             await s3Service.uploadFile(fullName, buffer, size, {
               'Content-Type': mimetype,

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1030,7 +1030,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
                   const { buffer, mediaType, fileName, size } = media;
                   const mimetype = mimeTypes.lookup(fileName).toString();
-                  const fullName = join(`${this.instance.id}`, received.key.remoteJid, mediaType, fileName);
+                  const fullName = join(`${this.instance.id}`, received.key.remoteJid, v4().replace(/-/g, ""), mediaType, fileName);
                   await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, {
                     'Content-Type': mimetype,
                   });

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1030,7 +1030,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
                   const { buffer, mediaType, fileName, size } = media;
                   const mimetype = mimeTypes.lookup(fileName).toString();
-                  const fullName = join(`${this.instance.id}`, received.key.remoteJid, v4().replace(/-/g, ""), mediaType, fileName);
+                  const fullName = join(`${this.instance.id}`, received.key.remoteJid, mediaType, v4().replace(/-/g, ""), fileName);
                   await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, {
                     'Content-Type': mimetype,
                   });

--- a/src/api/integrations/storage/s3/libs/minio.server.ts
+++ b/src/api/integrations/storage/s3/libs/minio.server.ts
@@ -64,6 +64,11 @@ const createBucket = async () => {
         await minioClient.makeBucket(bucketName);
       }
 
+      if (BUCKET?.IGNORE_POLICY) {
+        logger.info(`S3 Bucket ${bucketName} - ON`);
+        return true;
+      }
+
       await setBucketPolicy();
 
       logger.info(`S3 Bucket ${bucketName} - ON`);

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -249,6 +249,7 @@ export type S3 = {
   ENABLE: boolean;
   PORT?: number;
   USE_SSL?: boolean;
+  IGNORE_POLICY?: boolean;
   REGION?: string;
 };
 
@@ -552,6 +553,7 @@ export class ConfigService {
         ENABLE: process.env?.S3_ENABLED === 'true',
         PORT: Number.parseInt(process.env?.S3_PORT || '9000'),
         USE_SSL: process.env?.S3_USE_SSL === 'true',
+        IGNORE_POLICY: process.env?.IGNORE_POLICY === 'true',
         REGION: process.env?.S3_REGION,
       },
       AUTHENTICATION: {

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -553,7 +553,7 @@ export class ConfigService {
         ENABLE: process.env?.S3_ENABLED === 'true',
         PORT: Number.parseInt(process.env?.S3_PORT || '9000'),
         USE_SSL: process.env?.S3_USE_SSL === 'true',
-        IGNORE_POLICY: process.env?.IGNORE_POLICY === 'true',
+        IGNORE_POLICY: process.env?.S3_IGNORE_POLICY === 'true',
         REGION: process.env?.S3_REGION,
       },
       AUTHENTICATION: {


### PR DESCRIPTION
With this PR, evolution-api is now able to integrate to S3 compatible services that doesn't have bucket policy yet, like cloudflare r2 and also fixes upload of files with same name.