### PR TITLE
Adicionando rota de download de midia em base64 ou buffer

### DIFF
--- a/src/api/controllers/chat.controller.ts
+++ b/src/api/controllers/chat.controller.ts
@@ -2,6 +2,7 @@ import {
   ArchiveChatDto,
   BlockUserDto,
   DeleteMessage,
+  DownloadMediaMessageDto,
   getBase64FromMediaMessageDto,
   MarkChatUnreadDto,
   NumberDto,
@@ -80,6 +81,10 @@ export class ChatController {
 
   public async updatePrivacySettings({ instanceName }: InstanceDto, data: PrivacySettingDto) {
     return await this.waMonitor.waInstances[instanceName].updatePrivacySettings(data);
+  }
+
+  public async downloadMediaMessage({ instanceName }: InstanceDto, data: DownloadMediaMessageDto) {
+    return await this.waMonitor.waInstances[instanceName].downloadMediaMessage(data);
   }
 
   public async fetchBusinessProfile({ instanceName }: InstanceDto, data: ProfilePictureDto) {

--- a/src/api/dto/chat.dto.ts
+++ b/src/api/dto/chat.dto.ts
@@ -1,4 +1,6 @@
 import {
+  DownloadableMessage,
+  MediaType,
   proto,
   WAPresence,
   WAPrivacyGroupAddValue,
@@ -92,6 +94,13 @@ export class PrivacySettingDto {
   online: WAPrivacyOnlineValue;
   last: WAPrivacyValue;
   groupadd: WAPrivacyGroupAddValue;
+}
+
+export class DownloadMediaMessageDto {
+  downloadableMessage: DownloadableMessage;
+  type: MediaType;
+  timeout?: number;
+  returnType?: 'base64' | 'buffer' = 'buffer';
 }
 
 export class DeleteMessage {

--- a/src/api/routes/chat.router.ts
+++ b/src/api/routes/chat.router.ts
@@ -3,6 +3,7 @@ import {
   ArchiveChatDto,
   BlockUserDto,
   DeleteMessage,
+  DownloadMediaMessageDto,
   getBase64FromMediaMessageDto,
   MarkChatUnreadDto,
   NumberDto,
@@ -24,6 +25,7 @@ import {
   blockUserSchema,
   contactValidateSchema,
   deleteMessageSchema,
+  downloadMediaMessageSchema,
   markChatUnreadSchema,
   messageUpSchema,
   messageValidateSchema,
@@ -267,6 +269,16 @@ export class ChatRouter extends RouterBroker {
         });
 
         return res.status(HttpStatus.CREATED).json(response);
+      })
+      .post(this.routerPath('downloadMediaMessage'), ...guards, async (req, res) => {
+        const response = await this.dataValidate<DownloadMediaMessageDto>({
+          request: req,
+          schema: downloadMediaMessageSchema,
+          ClassRef: DownloadMediaMessageDto,
+          execute: (instance, data) => chatController.downloadMediaMessage(instance, data),
+        });
+
+        return res.status(HttpStatus.OK).json(response);
       });
   }
 

--- a/src/utils/readStreamWithTimeout.ts
+++ b/src/utils/readStreamWithTimeout.ts
@@ -1,0 +1,22 @@
+import { promisify } from 'util';
+
+export async function readStreamWithTimeout(stream: any, timeout: number = 30_000) {
+  const setTimeoutPromise = promisify(setTimeout);
+
+  let buffer = Buffer.from([]);
+  const chunks = [];
+  const timer: any = setTimeoutPromise(timeout).then(() => {
+    stream.destroy(new Error('Stream timeout'));
+  });
+
+  try {
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    buffer = Buffer.concat(chunks);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return buffer;
+}

--- a/src/validate/chat.schema.ts
+++ b/src/validate/chat.schema.ts
@@ -287,6 +287,26 @@ export const privacySettingsSchema: JSONSchema7 = {
   ...isNotEmpty('readreceipts', 'profile', 'status', 'online', 'last', 'groupadd'),
 };
 
+export const downloadMediaMessageSchema: JSONSchema7 = {
+  $id: v4(),
+  type: 'object',
+  properties: {
+    downloadableMessage: {
+      type: 'object',
+      properties: {
+        url: { type: 'string' },
+        mediaKey: { type: 'string' },
+        directPath: { type: 'string' },
+      },
+      ...isNotEmpty('url', 'mediaKey', 'directPath'),
+    },
+    type: { type: 'string', enum: ['image', 'video', 'audio', 'document', 'sticker', 'ptt'] },
+    timeout: { type: 'number', default: 30_000 },
+    returnType: { type: 'string', enum: ['base64', 'buffer'], default: 'buffer' },
+  },
+  ...isNotEmpty('downloadableMessage', 'type'),
+};
+
 export const profileNameSchema: JSONSchema7 = {
   $id: v4(),
   type: 'object',


### PR DESCRIPTION
POST /chat/downloadMediaMessage/:instance

```JSONC
{
    "downloadableMessage": {
        "mediaKey": "",
        "directPath": "",
        "url": ""
    },
    "type": "image", // image, video, audio, document, sticker, ptt
    // optional
    "timeout": 30000, // Milissegundos - padrão 30000 = 30s
    "returnType": "buffer" // buffer, base64 - padrão buffer
}
```

Implementado a função downloadContentFromMessage


