### PR TITLE
Corrige envio de áudio com marcação de mensagem na rota /message/sendWhatsAppAudio

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2406,7 +2406,7 @@ export class BaileysStartupService extends ChannelStartupService {
         ptt: true,
         mimetype: 'audio/ogg; codecs=opus',
       },
-      { presence: 'recording', delay: data?.delay },
+      { presence: 'recording', delay: data?.delay, quoted: data?.quoted },
     );
   }
 


### PR DESCRIPTION
Corrigi um problema na rota /message/sendWhatsAppAudio, onde ao tentar responder com um áudio marcando uma mensagem anterior (quoted), o áudio era enviado como uma mensagem nova, sem marcação.

## Summary by Sourcery

Bug Fixes:
- Include the quoted property when sending audio on /message/sendWhatsAppAudio so replies are correctly marked